### PR TITLE
Sarasa Gothic / 更纱黑体 / 更紗黑體 / 更紗ゴシック / 사라사 고딕: Add version 0.21.0

### DIFF
--- a/bucket/sarasa-gothic-cl.json
+++ b/bucket/sarasa-gothic-cl.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "description": "A CJK programming font based on Iosevka and Source Han Sans (Regional orthography: cl)",
+    "version": "0.21.0",
+    "license": "OFL-1.1",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.21.0/sarasa-gothic-ttf-0.21.0.7z#/dl.7z_",
+    "hash": "e127bcc3883ff6407e9a8cbf115cb736f843dd2e6b5cd986134bfa1ec74ab67c",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-cl-*.ttf')",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic CL' -Force -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
+            "  $font_name = $font_name.Replace(' Cl ', ' CL ')",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic CL' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "}",
+            "Write-Host \"The 'Sarasa Gothic CL' Font family has been installed for current user.\" -Foreground Magenta"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic CL' -Force -ErrorAction SilentlyContinue",
+            "Write-Host \"The 'Sarasa Gothic CL' Font family has been uninstalled.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    }
+}

--- a/bucket/sarasa-gothic-hc.json
+++ b/bucket/sarasa-gothic-hc.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "description": "A CJK programming font based on Iosevka and Source Han Sans (Regional orthography: HC)",
+    "version": "0.21.0",
+    "license": "OFL-1.1",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.21.0/sarasa-gothic-ttf-0.21.0.7z#/dl.7z_",
+    "hash": "e127bcc3883ff6407e9a8cbf115cb736f843dd2e6b5cd986134bfa1ec74ab67c",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-hc-*.ttf')",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic HC' -Force -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
+            "  $font_name = $font_name.Replace(' Hc ', ' HC ')",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic HC' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "}",
+            "Write-Host \"The 'Sarasa Gothic HC' Font family has been installed for current user.\" -Foreground Magenta"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic HC' -Force -ErrorAction SilentlyContinue",
+            "Write-Host \"The 'Sarasa Gothic HC' Font family has been uninstalled.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    }
+}

--- a/bucket/sarasa-gothic-j.json
+++ b/bucket/sarasa-gothic-j.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "description": "A CJK programming font based on Iosevka and Source Han Sans (Regional orthography: J)",
+    "version": "0.21.0",
+    "license": "OFL-1.1",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.21.0/sarasa-gothic-ttf-0.21.0.7z#/dl.7z_",
+    "hash": "e127bcc3883ff6407e9a8cbf115cb736f843dd2e6b5cd986134bfa1ec74ab67c",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-j-*.ttf')",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic J' -Force -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic J' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "}",
+            "Write-Host \"The 'Sarasa Gothic J' Font family has been installed for current user.\" -Foreground Magenta"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic J' -Force -ErrorAction SilentlyContinue",
+            "Write-Host \"The 'Sarasa Gothic J' Font family has been uninstalled.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    }
+}

--- a/bucket/sarasa-gothic-k.json
+++ b/bucket/sarasa-gothic-k.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "description": "A CJK programming font based on Iosevka and Source Han Sans (Regional orthography: K)",
+    "version": "0.21.0",
+    "license": "OFL-1.1",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.21.0/sarasa-gothic-ttf-0.21.0.7z#/dl.7z_",
+    "hash": "e127bcc3883ff6407e9a8cbf115cb736f843dd2e6b5cd986134bfa1ec74ab67c",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-k-*.ttf')",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic K' -Force -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic K' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "}",
+            "Write-Host \"The 'Sarasa Gothic K' Font family has been installed for current user.\" -Foreground Magenta"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic K' -Force -ErrorAction SilentlyContinue",
+            "Write-Host \"The 'Sarasa Gothic K' Font family has been uninstalled.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    }
+}

--- a/bucket/sarasa-gothic-sc.json
+++ b/bucket/sarasa-gothic-sc.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "description": "A CJK programming font based on Iosevka and Source Han Sans (Regional orthography: SC)",
+    "version": "0.21.0",
+    "license": "OFL-1.1",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.21.0/sarasa-gothic-ttf-0.21.0.7z#/dl.7z_",
+    "hash": "e127bcc3883ff6407e9a8cbf115cb736f843dd2e6b5cd986134bfa1ec74ab67c",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-sc-*.ttf')",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic SC' -Force -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
+            "  $font_name = $font_name.Replace(' Sc ', ' SC ')",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic SC' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "}",
+            "Write-Host \"The 'Sarasa Gothic SC' Font family has been installed for current user.\" -Foreground Magenta"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic SC' -Force -ErrorAction SilentlyContinue",
+            "Write-Host \"The 'Sarasa Gothic SC' Font family has been uninstalled.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    }
+}

--- a/bucket/sarasa-gothic-tc.json
+++ b/bucket/sarasa-gothic-tc.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "description": "A CJK programming font based on Iosevka and Source Han Sans (Regional orthography: TC)",
+    "version": "0.21.0",
+    "license": "OFL-1.1",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.21.0/sarasa-gothic-ttf-0.21.0.7z#/dl.7z_",
+    "hash": "e127bcc3883ff6407e9a8cbf115cb736f843dd2e6b5cd986134bfa1ec74ab67c",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand 7z -ArgumentList('e', \"$dir\\dl.7z_\" ,\"-o$dir\", '*-tc-*.ttf')",
+            "Remove-Item \"$dir\\dl.7z_\"",
+            "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic TC' -Force -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
+            "  $font_name = $font_name.Replace(' Tc ', ' TC ')",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic TC' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "}",
+            "Write-Host \"The 'Sarasa Gothic TC' Font family has been installed for current user.\" -Foreground Magenta"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic TC' -Force -ErrorAction SilentlyContinue",
+            "Write-Host \"The 'Sarasa Gothic TC' Font family has been uninstalled.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z#/dl.7z_"
+    }
+}

--- a/bucket/sarasa-gothic.json
+++ b/bucket/sarasa-gothic.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://github.com/be5invis/Sarasa-Gothic",
+    "description": "A CJK programming font based on Iosevka and Source Han Sans",
+    "version": "0.21.0",
+    "license": "OFL-1.1",
+    "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.21.0/sarasa-gothic-ttf-0.21.0.7z",
+    "hash": "e127bcc3883ff6407e9a8cbf115cb736f843dd2e6b5cd986134bfa1ec74ab67c",
+    "installer": {
+        "script": [
+            "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic' -Force -ErrorAction SilentlyContinue | Out-Null",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
+            "  $font_name = $font_name.Replace(' Cl ', ' CL ')",
+            "  $font_name = $font_name.Replace(' Hc ', ' HC ')",
+            "  $font_name = $font_name.Replace(' Sc ', ' SC ')",
+            "  $font_name = $font_name.Replace(' Tc ', ' TC ')",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic' -Force -ErrorAction SilentlyContinue",
+            "Write-Host \"The 'Sarasa Gothic' Font family has been uninstalled.\" -Foreground Magenta"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/be5invis/Sarasa-Gothic/releases/download/v$version/sarasa-gothic-ttf-$version.7z"
+    }
+}


### PR DESCRIPTION
- install for current user only, so these manifest/fonts can't install for other users via global installation.
- install these manifests with global installation for create hardlink, if scoop and OS are not in the same partition(https://github.com/HUMORCE/scoop-nuke/pull/16)
- registry items of name has been format to standard font name
- <del>no move/copy operation, font files stored in scoop apps dir</del>(https://github.com/HUMORCE/scoop-nuke/pull/16)
- **may** no reboot required for un/install/update


_base on matthewjberger/scoop-nerd-fonts manifests_