### PR TITLE
sarasa-gothic: Create hardlink for compatibility

### DIFF
--- a/bucket/sarasa-gothic-cl.json
+++ b/bucket/sarasa-gothic-cl.json
@@ -13,7 +13,9 @@
             "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
             "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
             "  $font_name = $font_name.Replace(' Cl ', ' CL ')",
-            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic CL' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "  $file_name = $_.Name",
+            "  New-Item -ItemType HardLink -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Value \"$dir\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic CL' -Name $font_name -Value \"$dir\\$file_name\" -Force | Out-Null",
             "}",
             "Write-Host \"The 'Sarasa Gothic CL' Font family has been installed for current user.\" -Foreground Magenta"
         ]
@@ -21,6 +23,10 @@
     "uninstaller": {
         "script": [
             "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic CL' -Force -ErrorAction SilentlyContinue",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $file_name = $_.Name",
+            "  Remove-Item -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "}",
             "Write-Host \"The 'Sarasa Gothic CL' Font family has been uninstalled.\" -Foreground Magenta"
         ]
     },

--- a/bucket/sarasa-gothic-hc.json
+++ b/bucket/sarasa-gothic-hc.json
@@ -13,7 +13,9 @@
             "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
             "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
             "  $font_name = $font_name.Replace(' Hc ', ' HC ')",
-            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic HC' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "  $file_name = $_.Name",
+            "  New-Item -ItemType HardLink -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Value \"$dir\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic HC' -Name $font_name -Value \"$dir\\$file_name\" -Force | Out-Null",
             "}",
             "Write-Host \"The 'Sarasa Gothic HC' Font family has been installed for current user.\" -Foreground Magenta"
         ]
@@ -21,6 +23,10 @@
     "uninstaller": {
         "script": [
             "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic HC' -Force -ErrorAction SilentlyContinue",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $file_name = $_.Name",
+            "  Remove-Item -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "}",
             "Write-Host \"The 'Sarasa Gothic HC' Font family has been uninstalled.\" -Foreground Magenta"
         ]
     },

--- a/bucket/sarasa-gothic-j.json
+++ b/bucket/sarasa-gothic-j.json
@@ -12,7 +12,9 @@
             "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic J' -Force -ErrorAction SilentlyContinue | Out-Null",
             "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
             "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
-            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic J' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "  $file_name = $_.Name",
+            "  New-Item -ItemType HardLink -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Value \"$dir\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic J' -Name $font_name -Value \"$dir\\$file_name\" -Force | Out-Null",
             "}",
             "Write-Host \"The 'Sarasa Gothic J' Font family has been installed for current user.\" -Foreground Magenta"
         ]
@@ -20,6 +22,10 @@
     "uninstaller": {
         "script": [
             "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic J' -Force -ErrorAction SilentlyContinue",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $file_name = $_.Name",
+            "  Remove-Item -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "}",
             "Write-Host \"The 'Sarasa Gothic J' Font family has been uninstalled.\" -Foreground Magenta"
         ]
     },

--- a/bucket/sarasa-gothic-k.json
+++ b/bucket/sarasa-gothic-k.json
@@ -12,7 +12,9 @@
             "New-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic K' -Force -ErrorAction SilentlyContinue | Out-Null",
             "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
             "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
-            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic K' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "  $file_name = $_.Name",
+            "  New-Item -ItemType HardLink -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Value \"$dir\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic K' -Name $font_name -Value \"$dir\\$file_name\" -Force | Out-Null",
             "}",
             "Write-Host \"The 'Sarasa Gothic K' Font family has been installed for current user.\" -Foreground Magenta"
         ]
@@ -20,6 +22,10 @@
     "uninstaller": {
         "script": [
             "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic K' -Force -ErrorAction SilentlyContinue",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $file_name = $_.Name",
+            "  Remove-Item -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "}",
             "Write-Host \"The 'Sarasa Gothic K' Font family has been uninstalled.\" -Foreground Magenta"
         ]
     },

--- a/bucket/sarasa-gothic-sc.json
+++ b/bucket/sarasa-gothic-sc.json
@@ -13,7 +13,9 @@
             "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
             "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
             "  $font_name = $font_name.Replace(' Sc ', ' SC ')",
-            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic SC' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "  $file_name = $_.Name",
+            "  New-Item -ItemType HardLink -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Value \"$dir\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic SC' -Name $font_name -Value \"$dir\\$file_name\" -Force | Out-Null",
             "}",
             "Write-Host \"The 'Sarasa Gothic SC' Font family has been installed for current user.\" -Foreground Magenta"
         ]
@@ -21,6 +23,10 @@
     "uninstaller": {
         "script": [
             "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic SC' -Force -ErrorAction SilentlyContinue",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $file_name = $_.Name",
+            "  Remove-Item -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "}",
             "Write-Host \"The 'Sarasa Gothic SC' Font family has been uninstalled.\" -Foreground Magenta"
         ]
     },

--- a/bucket/sarasa-gothic-tc.json
+++ b/bucket/sarasa-gothic-tc.json
@@ -13,7 +13,9 @@
             "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
             "  $font_name = (Get-Culture).TextInfo.ToTitleCase($_.BaseName.Replace('-', ' ')) + ' (TrueType)'",
             "  $font_name = $font_name.Replace(' Tc ', ' TC ')",
-            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic TC' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "  $file_name = $_.Name",
+            "  New-Item -ItemType HardLink -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Value \"$dir\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic TC' -Name $font_name -Value \"$dir\\$file_name\" -Force | Out-Null",
             "}",
             "Write-Host \"The 'Sarasa Gothic TC' Font family has been installed for current user.\" -Foreground Magenta"
         ]
@@ -21,6 +23,10 @@
     "uninstaller": {
         "script": [
             "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic TC' -Force -ErrorAction SilentlyContinue",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $file_name = $_.Name",
+            "  Remove-Item -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "}",
             "Write-Host \"The 'Sarasa Gothic TC' Font family has been uninstalled.\" -Foreground Magenta"
         ]
     },

--- a/bucket/sarasa-gothic.json
+++ b/bucket/sarasa-gothic.json
@@ -14,13 +14,20 @@
             "  $font_name = $font_name.Replace(' Hc ', ' HC ')",
             "  $font_name = $font_name.Replace(' Sc ', ' SC ')",
             "  $font_name = $font_name.Replace(' Tc ', ' TC ')",
-            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic' -Name $font_name -Value $_.FullName -Force | Out-Null",
+            "  $file_name = $_.Name",
+            "  New-Item -ItemType HardLink -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Value \"$dir\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "  New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic' -Name $font_name -Value \"$dir\\$file_name\" -Force | Out-Null",
+            "}",
             "}"
         ]
     },
     "uninstaller": {
         "script": [
             "Remove-Item -Path 'HKCU:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\\Sarasa Gothic' -Force -ErrorAction SilentlyContinue",
+            "Get-ChildItem $dir -filter 'sarasa*.ttf' | ForEach-Object {",
+            "  $file_name = $_.Name",
+            "  Remove-Item -Path \"$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts\\$file_name\" -Force -ErrorAction SilentlyContinue | Out-Null",
+            "}",
             "Write-Host \"The 'Sarasa Gothic' Font family has been uninstalled.\" -Foreground Magenta"
         ]
     },


### PR DESCRIPTION
in the previous publish(https://github.com/HUMORCE/scoop-nuke/pull/15), some apps can't select the fonts installed via these manifest.
e.g. chrome/firefox

**install these manifests with global installation for create hardlink, if scoop and OS are not in the same partition.**