### PR TITLE
appflowy@0.0.3: Update `extract_dir`

### DIFF
--- a/bucket/appflowy.json
+++ b/bucket/appflowy.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0-only",
     "url": "https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.0.3/AppFlowy-windows-x86.zip",
     "hash": "0c193add077a823720cbfb22ea85d213078e12ff3ccfbd86845e612fdc85c5a6",
-    "extract_dir": "AppFlowy-Windows",
+    "extract_dir": "AppFlowy",
     "shortcuts": [
         [
             "app_flowy.exe",


### PR DESCRIPTION
Resolves install failing. The root folder inside the zip archive was renamed between releases.

In v0.0.2 it was `"AppFlowy-Windows"` but was changed to just `"AppFlowy"` in v0.0.3-beta.1.